### PR TITLE
Quality of life improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV HOME="/config"
 EXPOSE 9443
 
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cron libio-socket-ssl-perl libmojolicious-perl curl ca-certificates xz-utils \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cron libcrypt-bcrypt-perl libio-socket-ssl-perl libmojolicious-perl curl ca-certificates xz-utils \
     && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 RUN curl -sSL https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz -o /tmp/s6-overlay-noarch.tar.xz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV HOME="/config"
 EXPOSE 9443
 
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cron libmojolicious-perl curl ca-certificates xz-utils \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cron libio-socket-ssl-perl libmojolicious-perl curl ca-certificates xz-utils \
     && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 RUN curl -sSL https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz -o /tmp/s6-overlay-noarch.tar.xz \

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ acmesh_extra_params_install_cert => [
 acmesh_extra_params_issue => [
     '--config-home /cert-data',
 ],
+
+# The directory to store acmeproxy.pl.crt and acmeproxy.pl.key
+keypair_directory => '/cert-data',
 ```
 
 Use the Docker CLI you can achive something similar using:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ services:
       - 9443/tcp
     volumes:
       - ./config:/config:rw
+      # Optionally store the generated certificate data on a persistent volume
+      # - ./cert-data:/cert-data:rw
+```
+
+Note that if you want to store the generated certificate data on a persistant volume, you should add something like the following to your `acmeproxy.pl.conf` file:
+```perl
+# Extra params to pass when invoking acme.sh --install
+acmesh_extra_params_install => [
+    '--config-home /cert-data',
+],
+
+# Extra params to pass when invoking acme.sh --install-cert
+acmesh_extra_params_install_cert => [
+    '--config-home /cert-data',
+],
+
+# Extra params to pass when invoking acme.sh --issue
+acmesh_extra_params_issue => [
+    '--config-home /cert-data',
+],
 ```
 
 Use the Docker CLI you can achive something similar using:

--- a/acmeproxy.pl
+++ b/acmeproxy.pl
@@ -160,7 +160,7 @@ sub acme_gencert ($hn) {
   my $extra_params = join(' ', @{$config->{acmesh_extra_params}});
   my $domain_list = join(' ', map { qq/-d ${_}/} split(/\s+/, $hn));
   my $ret = system("$acme_home/acme.sh --force --log --issue $extra_params --dns $config->{dns_provider} $domain_list && ".
-	     "$acme_home/acme.sh --log --install-cert -d $hn --key-file $acme_home/acmeproxy.pl.key ".
+	     "$acme_home/acme.sh --log --install-cert $domain_list --key-file $acme_home/acmeproxy.pl.key ".
 		    "--fullchain-file $acme_home/acmeproxy.pl.crt");
   die("Could not create TLS certificate for $hn") if ($ret);
 }

--- a/acmeproxy.pl
+++ b/acmeproxy.pl
@@ -286,7 +286,7 @@ __DATA__
         {
             'user' => 'bob',
             'pass' => 'dobbs',
-            'hash' => '$2b$12$ZkfzP1DVcFHSXyrtMRXJR.Ny2fpSixG00oLI2iMkT3yArpzs/921u',
+            # 'hash' => '$2b$12$ZkfzP1DVcFHSXyrtMRXJR.Ny2fpSixG00oLI2iMkT3yArpzs/921u',
             'host' => 'bob.int.example.com',
         },
         # Bob is hosting two TLS services on his machine with different TLS hostnames
@@ -294,7 +294,7 @@ __DATA__
         {
             'user' => 'bob',
             'pass' => 'dobbs',
-            'hash' => '$2b$12$ZkfzP1DVcFHSXyrtMRXJR.Ny2fpSixG00oLI2iMkT3yArpzs/921u',
+            # 'hash' => '$2b$12$ZkfzP1DVcFHSXyrtMRXJR.Ny2fpSixG00oLI2iMkT3yArpzs/921u',
             'host' => 'subgenius.int.example.com',
         },
     ],

--- a/acmeproxy.pl
+++ b/acmeproxy.pl
@@ -164,7 +164,8 @@ sub acme_gencert ($hn) {
   my $ret = system("$acme_home/acme.sh --log --issue $extra_params_issue --dns $config->{dns_provider} $domain_list && ".
 	     "$acme_home/acme.sh --log --install-cert $extra_params_install_cert $domain_list --key-file $acme_home/acmeproxy.pl.key ".
 		    "--fullchain-file $acme_home/acmeproxy.pl.crt");
-  die("Could not create TLS certificate for $hn") if ($ret);
+  # --issue will return 2 when renewal is skipped due to certs still being valid
+  die("Could not create TLS certificate for $hn") if ($ret != 0 && $ret != 2);
 }
 
 # Write the example configuration file

--- a/acmeproxy.pl
+++ b/acmeproxy.pl
@@ -48,6 +48,15 @@ my $config = plugin 'Config' => {file => cwd().'/acmeproxy.pl.conf', format => '
 # Early sanity checks
 die("acme dnslib provider not found: $config->{dns_provider}\n")
   unless (-f "$acme_home/dnsapi/$config->{dns_provider}.sh");
+if (!exists($config->{acmesh_extra_params_install})) {
+  $config->{acmesh_extra_params_install} = [];
+}
+if (!exists($config->{acmesh_extra_params_install_cert})) {
+  $config->{acmesh_extra_params_install_cert} = [];
+}
+if (!exists($config->{acmesh_extra_params_issue})) {
+  $config->{acmesh_extra_params_issue} = [];
+}
 foreach my $auth (@{$config->{auth}}) {
   if (exists($auth->{pass})) {
     logg "One or more users are defined with plaintext passwords. You should convert them to bcrypt hashes!";

--- a/acmeproxy.pl
+++ b/acmeproxy.pl
@@ -166,7 +166,7 @@ sub acme_gencert ($hn) {
   die("Could not create TLS certificate for $hn") if ($ret != 0 && $ret >> 8 != 2);
 
   my $extra_params_install_cert = join(' ', @{$config->{acmesh_extra_params_install_cert}});
-	my $ret = system("$acme_home/acme.sh --log --install-cert $extra_params_install_cert $domain_list " .
+	$ret = system("$acme_home/acme.sh --log --install-cert $extra_params_install_cert $domain_list " .
                    "--key-file $acme_home/acmeproxy.pl.key --fullchain-file $acme_home/acmeproxy.pl.crt");
   die("Could not install TLS certificate for $hn") if ($ret);
 }

--- a/acmeproxy.pl
+++ b/acmeproxy.pl
@@ -159,7 +159,7 @@ sub acme_gencert ($hn) {
 
   my $extra_params = join(' ', @{$config->{acmesh_extra_params}});
   my $domain_list = join(' ', map { qq/-d ${_}/} split(/\s+/, $hn));
-  my $ret = system("$acme_home/acme.sh --force --log --issue $extra_params --dns $config->{dns_provider} $domain_list && ".
+  my $ret = system("$acme_home/acme.sh --log --issue $extra_params --dns $config->{dns_provider} $domain_list && ".
 	     "$acme_home/acme.sh --log --install-cert $domain_list --key-file $acme_home/acmeproxy.pl.key ".
 		    "--fullchain-file $acme_home/acmeproxy.pl.crt");
   die("Could not create TLS certificate for $hn") if ($ret);

--- a/acmeproxy.pl
+++ b/acmeproxy.pl
@@ -45,9 +45,7 @@ sub logg ($in) { say strftime("[%a %b %e %I:%M:%S %p %Z %Y] ", localtime()) . $i
 write_config() unless (-f 'acmeproxy.pl.conf');
 my $config = plugin 'Config' => {file => cwd().'/acmeproxy.pl.conf', format => 'perl'};
 
-# Early sanity checks
-die("acme dnslib provider not found: $config->{dns_provider}\n")
-  unless (-f "$acme_home/dnsapi/$config->{dns_provider}.sh");
+# Backwards compatibility checks/updates
 if (!exists($config->{acmesh_extra_params_install})) {
   $config->{acmesh_extra_params_install} = [];
 }
@@ -69,6 +67,10 @@ foreach (keys %{$config->{env}}) { $ENV{$_} = $config->{env}->{$_}; }
 
 # Install acme.sh if it isn't installed already
 acme_install() unless (-f "$acme_home/acme.sh");
+
+# Early sanity checks
+die("acme dnslib provider not found: $config->{dns_provider}\n")
+  unless (-f "$acme_home/dnsapi/$config->{dns_provider}.sh");
 
 # Generate a TLS certificate for ourselves if one doesn't exist
 acme_gencert($config->{hostname})


### PR DESCRIPTION
My apologies for this large of a pull request, but this started off as a bit exploratory to see how well this would work for my needs and just sort of snowballed.  If you want, I **might** be able to rework things so that I can submit a couple smaller/more focused PRs instead of this large one.  With that disclaimer out of the way, here's what I changed and my reasoning for it:

- `acme_gencert` got a bit of attention to make it a bit easier to use.  First, it can support multiple space delimited domains (I find this useful for some split horizon DNS setups).  Second, the issue/install-cert commands are split up so that we can better handle certificates that don't need to be renewed yet.  Finally, we don't forcefully issue certificates, as I found that was a great way to get myself rate limited (oops).
- You can specify extra parameters to pass to `acme.sh --install`, `acme.sh --install-cert`, and `acme.sh --issue`.  I use this to specify a config home on a persistent volume in Docker, as well as to use Lets Encrypt instead of ZeroSSL.
- The docker image will install the required package for IO::Socket::SSL so that we can actually serve TLS requests.
- The docker image will also install the required package for Crypt::Bcrypt which lets us put hashed passwords in the config file!  This should be backwards compatible because they are stored in `hash` which is checked first and if it's not available we will fall back to `pass`.  That said though, a log entry is written when users have a `pass` value.
- The directory that is used to store `acmeproxy.pl.crt` and `acmeproxy.pl.key` is configurable.  This is another change for the sake of running this in a docker container.

This all appears to be functioning correctly in my testing, but I'll admit that I'm not a perl dev so it's possible that I missed something.