### PR TITLE
Add Accept-header content negotiation to /present and /cleanup for compatibility with Traefik (and others?)

### DIFF
--- a/acmeproxy.pl
+++ b/acmeproxy.pl
@@ -97,7 +97,12 @@ sub handle_request {
 
   my $cmd_res = acme_cmd($command, $data->{fqdn}, $data->{value});
 
-  $c->render(text => $cmd_res->{'text'}, status => $cmd_res->{'status'});
+  my $accept = $c->req->headers->accept;
+  if (defined $accept && $accept eq 'application/json') {
+    $c->render(json => $cmd_res->{json}, status => $cmd_res->{status});
+  } else {
+    $c->render(text => $cmd_res->{text}, status => $cmd_res->{status});
+  }
 }
 
 # Mojo web routes
@@ -133,8 +138,13 @@ app->start('daemon', '-l', "https://$config->{bind}?cert=$acmeproxy_crt_file&key
 # Crude but effective. Slimy yet satisfying.
 sub acme_cmd ($action, $fqdn, $value) {
   # Let's not pass weird characters to a shell
-  return { text => "invalid characters in fqdn", status => 400} unless ($fqdn =~ /^[\w_\.-]+$/);
-  return { text => "invalid characters in value", status => 400} unless ($value =~ /^[\w_\.-]+$/);
+  return { status => 400, text => "invalid characters in fqdn",
+           json => { error => "invalid characters in fqdn" } }
+    unless ($fqdn =~ /^[\w_\.-]+$/);
+  return { status => 400, text => "invalid characters in value",
+           json => { error => "invalid characters in value" } }
+    unless ($value =~ /^[\w_\.-]+$/);
+  my $fqdn_unsanitized = $fqdn;
   $fqdn =~ s/\.+$//; # Some acme.sh plugins add an additional . to the end of the hostname
 
   # Source acme.sh and the dnsapi provider, then call the provider's add/rm function.
@@ -146,11 +156,13 @@ sub acme_cmd ($action, $fqdn, $value) {
                '"$0" "$1" "$2"';
   logg "executing: $func \"$fqdn\" \"$value\"";
 
-  # acme.sh/dnslib/dns_acmeproxy.sh explicitly looks for the quotes around $value to determine success
-  # other clients expect full JSON and fqdn needs to end with "."
-  return { text => "{\"fqdn\": \"$fqdn.\", \"value\": \"$value\"}", status => 200}
-    unless (system('/usr/bin/env', 'bash', '-c', $script, $func, $fqdn, $value));
-  return { text => "failed. check acmeproxy.pl logs", status => 500};
+  return {
+    status => 200,
+    text   => qq/success: $fqdn "$value"/,
+    json   => { fqdn => $fqdn_unsanitized, value => $value },
+  } unless (system('/usr/bin/env', 'bash', '-c', $script, $func, $fqdn, $value));
+  return { status => 500, text => "failed. check acmeproxy.pl logs",
+           json => { error => "failed. check acmeproxy.pl logs" } };
 }
 
 # Authentication helper. Checks user:pass and fqdn against our authlist

--- a/t/20-acme_cmd.t
+++ b/t/20-acme_cmd.t
@@ -29,19 +29,23 @@ for my $c (@metachars) {
 # --- happy path ------------------------------------------------------------
 my $res = main::acme_cmd('add', '_acme-challenge.bob.example.com', 'token123');
 is($res->{status}, 200, 'valid add returns 200');
-like($res->{text}, qr/"fqdn":\s*"_acme-challenge\.bob\.example\.com\."/,
-    'response includes fqdn with trailing dot');
-like($res->{text}, qr/"value":\s*"token123"/,
-    'response includes value');
+like($res->{text}, qr/^success: _acme-challenge\.bob\.example\.com "token123"$/,
+    'text response is "success: <fqdn> \"<value>\""');
+is_deeply($res->{json},
+    { fqdn => '_acme-challenge.bob.example.com', value => 'token123' },
+    'json response is {fqdn, value} dict');
 
 # --- trailing-dot normalization -------------------------------------------
+# text uses stripped fqdn; json preserves the caller's exact input
 $res = main::acme_cmd('add', '_acme-challenge.bob.example.com.', 'tok');
-like($res->{text}, qr/"fqdn":\s*"_acme-challenge\.bob\.example\.com\."/,
-    'trailing dot stripped then re-added');
+like($res->{text}, qr/^success: _acme-challenge\.bob\.example\.com "tok"$/,
+    'text uses fqdn with trailing dots stripped');
+is($res->{json}{fqdn}, '_acme-challenge.bob.example.com.',
+    'json preserves caller fqdn with its trailing dot');
 
 $res = main::acme_cmd('add', '_acme-challenge.bob.example.com...', 'tok');
-like($res->{text}, qr/"fqdn":\s*"_acme-challenge\.bob\.example\.com\."/,
-    'multiple trailing dots collapsed to one');
+like($res->{text}, qr/^success: _acme-challenge\.bob\.example\.com "tok"$/,
+    'text strips multiple trailing dots');
 
 # --- rm action -------------------------------------------------------------
 $res = main::acme_cmd('rm', '_acme-challenge.bob.example.com', 'token123');

--- a/t/30-routes.t
+++ b/t/30-routes.t
@@ -68,8 +68,8 @@ clear_log();
 $t->post_ok('/present' => { Authorization => basic('bob', 'dobbs') }
                        => json => { fqdn => '_acme-challenge.bob.example.com', value => 'tok' })
     ->status_is(200)
-    ->content_like(qr/"fqdn":\s*"_acme-challenge\.bob\.example\.com\."/)
-    ->content_like(qr/"value":\s*"tok"/);
+    ->content_like(qr/^success: _acme-challenge\.bob\.example\.com "tok"$/)
+    ->header_like('Content-Type', qr{^text/});
 ok((grep { /auth: bob successfully authenticated/ } @LOG_LINES),
    'success audit log present')
     or diag explain \@LOG_LINES;
@@ -86,7 +86,7 @@ clear_calls();
 $t->post_ok('/cleanup' => { Authorization => basic('bob', 'dobbs') }
                        => json => { fqdn => '_acme-challenge.bob.example.com', value => 'tok' })
     ->status_is(200)
-    ->content_like(qr/"fqdn":\s*"_acme-challenge\.bob\.example\.com\."/);
+    ->content_like(qr/^success: _acme-challenge\.bob\.example\.com "tok"$/);
 
 @lines = grep { length } split /\n/, call_log();
 is(scalar @lines, 1, '/cleanup invokes dnsapi once (rm only)');


### PR DESCRIPTION
When the client sends Accept: application/json, return a real JSON dict ({fqdn, value} on success, {error} on failure). Anything else gets the plain-text "success: <fqdn> \"<value>\"" form.

Adapted from Firegore's Traefik-compatibility fork https://github.com/madcamel/acmeproxy.pl/commit/6848958d9867e254984ad4c5328d8b5589526e59